### PR TITLE
Linearalization in getxxnorm

### DIFF
--- a/R/by_s_m.R
+++ b/R/by_s_m.R
@@ -51,7 +51,8 @@ by_s_m = function(thres=thres,z0=z0,zmax=zmax,z=z,sigma=sigma) {
 
   # SUBROUTINE GET_XX_norm(anormx,anormy,N,       N1, X0,    DX, X,     Y,         XX,YY)
   # call GET_XX_norm(      ax,    ay,    i2-i1+1, nn, z(i1), dz, z(i1), sigma(i1), XX,YY)
-  results = getxxnorm(z[i1:i2],sigma[i1:i2],nn,z[i1],dz)
+  results = getxxnorm(z[i1:i2],sigma[i1:i2])
+  #results = getxxnorm(z[i1:i2],sigma[i1:i2],nn,z[i1],dz)
 
   ni = s_m_p(thres,results$xx,results$yy)
   k=ni[2]

--- a/R/by_s_m3.R
+++ b/R/by_s_m3.R
@@ -49,7 +49,8 @@ by_s_m3 = function(nr,z0,zmax,z,sigma) {
 
   # SUBROUTINE GET_XX_norm(anormx,anormy,N,       N1, X0,    DX, X,     Y,         XX,YY)
   # call GET_XX_norm(      ax,    ay,    i2-i1+1, nn, z(i1), dz, z(i1), sigma(i1), XX,YY)
-  results = getxxnorm(z[i1:i2],sigma[i1:i2],nn,z[i1],dz)
+  #results = getxxnorm(z[i1:i2],sigma[i1:i2],nn,z[i1],dz)
+  results = getxxnorm(z[i1:i2],sigma[i1:i2])
 
   s_mNresults = s_mN(nr,results$xx,results$yy)
   ni = s_mNresults$ni

--- a/R/getxxnorm.R
+++ b/R/getxxnorm.R
@@ -1,12 +1,9 @@
 #' @export
-#' @description Interpolate and normalize a vector of samples. X and Y will be linearly interpolated to match the length of X0 and will be normalized so that the first point is (0,0) and the last point is (1,1). Vector x are the input x values, must be in ascending order.
+#' @description Normalize a vector of samples. X and Y  will be normalized so that the first point is (0,0) and the last point is (1,1). Vector x are the input x values, must be in ascending order.
 #'
-#' @title Interpolate and normalize a vector of samples.
+#' @title Normalize a vector of samples.
 #' @param x [REAL(N)] input x-axis array (should be in "chronological" order)
 #' @param y [REAL(N)] input y-axis array
-#' @param nn [INTEGER] input, desired dimension of output xx,yy vectors
-#' @param x0 [REAL] start point along the x-axis; i.e., xx[1] = x0
-#' @param dx [REAL] step value for xx; i.e., dx = xx[i+1]-xx[i] for all i<nn
 #' @return Output is a list with:
 #' anormx, the normalization value used to make the last x == 1.
 #' anormy, the normalization value used to make the last y == 1.
@@ -14,27 +11,27 @@
 #'
 # @examples
 
-getxxnorm <- function(x,y,nn,x0,dx) {
-  xx = x0 + dx*(0:(nn-1))    # Spread xx out linearly.
-  yy <- rep(0,nn)            # Reserve space for y values.
+getxxnorm <- function(x,y) {
+  #xx = x0 + dx*(0:(nn-1))    # Spread xx out linearly.
+  #yy <- rep(0,nn)            # Reserve space for y values.
 
-  j = 1
-  for ( i in 1:nn ) { # Loop over output calculating yy[i]
-    # j = 1 + sum(xx[i] >= x)  # Equivalent to following three lines.
-    while( (xx[i] >= x[j]) && (j < length(x)) ) {
-      j <- j+1
-    }
-    if( j == 1 ) {
-      yy[i] <- y[1]
-    }
-    else {
-      yy[i] <- y[j-1]+(xx[i]-x[j-1])/(x[j]-x[j-1])*(y[j]-y[j-1])
-    }
-  }
-  anormx = xx[length(xx)] - xx[1]
-  anormy = yy[length(yy)] - yy[1]
-  xx = (xx - xx[1])/anormx
-  yy = (yy - yy[1])/anormy
+  #j = 1
+  #for ( i in 1:nn ) { # Loop over output calculating yy[i]
+  #  # j = 1 + sum(xx[i] >= x)  # Equivalent to following three lines.
+  #  while( (xx[i] >= x[j]) && (j < length(x)) ) {
+  #    j <- j+1
+  #  }
+  #  if( j == 1 ) {
+  #    yy[i] <- y[1]
+  #  }
+  #  else {
+  #    yy[i] <- y[j-1]+(xx[i]-x[j-1])/(x[j]-x[j-1])*(y[j]-y[j-1])
+  #  }
+  #}
+  anormx = x[length(x)] - x[1]
+  anormy = y[length(y)] - y[1]
+  xx = (x - x[1])/anormx
+  yy = (y - y[1])/anormy
 
   list(anormx=anormx,anormy=anormy,xx=xx,yy=yy)
 }

--- a/R/s_m_p.R
+++ b/R/s_m_p.R
@@ -29,7 +29,7 @@
 
 s_m_p = function(eps,x,y) {
   # This code generates Nr intervals in vector Ni
-  if(is.unsorted(x)==TRUE) stop("x is not an increasing vector")
+  #if(is.unsorted(x)==TRUE) stop("x is not an increasing vector")
   #  Nr=2
   #      m=NINT(FLOAT(N)/FLOAT(Nr))
   #        ni(1)=1

--- a/R/wtr_layer.R
+++ b/R/wtr_layer.R
@@ -20,52 +20,87 @@
 #' @seealso \code{cline_calc()}
 wtr_layer <-
   function(thres = 0.1,
-           z0 = "auto",
+           z0 = 1.5,
            zmax = 150,
            depth = depth,
            measure = measure,
            nseg = "unconstrained") {
-    if( is.unsorted(depth[depth>z0])==TRUE){
-        warning("depth vector is unsorted")
-        return(data.frame(
-          min_depth = NA,
-          nseg = NA,
-          mld = NA,
-          cline = NA
-        ))
-      } else{
-    ### Index numbers of longest ordered portion of a vector
-    ### http://stackoverflow.com/a/42077739/5596534
-    #order_seq <- function(x, run_length=10) {
-    #  ## Resistant to slight decreases in depth
-    #  ## returns Index range between first run of increasing numbers greater 10 and the max depth
-    #  ## Index where the runs start
-    #  s = 1L + c(0L, which(x[-1L] < x[-length(x)]), length(x))
-    #  ## Index of first run of numbers greater than run_lenght (defaults to 10)
-    #  w = min(which(diff(s) > run_length))
-    #  ## Index of fIrst instance of max depth
-    #  s[w]:min(which(x %in% max(x)))
-    #}
+    ### Set a minimum depth readings
+    #if( is.unsorted(depth[depth>z0])==TRUE){
+    #  warning("depth vector is unsorted")
+    #  return(data.frame(
+    #    min_depth = NA,
+    #    nseg = NA,
+    #    depth = NA,
+    #    measure = NA
+    #  ))
+    #} else{
+    if (length(depth) >= 10) {
+      
+      #seq_rm <- function(x, run_length = 10) {
+      #  
+      #  ## Resistant to slight decreases in depth
+      #  ## returns Index range between first run of increasing numbers greater 10 and the max depth
+      #  ## Index where the runs start
+      #  s = 1L + c(0L, which(x[-1L] < x[-length(x)]), length(x))
+      #  ## Index of first run of numbers greater than run_length (defaults to 10)
+      #  w = min(which(diff(s) > run_length))
+      #  x = x[s[w]:length(x)]
+      #  
+      #  
+      #  if (is.unsorted(x)==TRUE){
+      #  
+      #  n_pre = length(x)
+      #  
+      #  while (is.unsorted(x) == TRUE) {
+      #    x <- x[which(diff(x) > 0)]
+      #  }
+      #  
+      #  n_loss = round(1 - (length(x) / n_pre), 3) * 100
+      #  
+      #  if (n_loss > 0) {
+      #    warning(
+      #      paste0(
+      #        "Possible data quality issue: ",
+      #        n_loss,
+      #        "% of data removed due to non-increasing depth vector"
+      #      )
+      #    )
+      #    
+      #  }
+      #  }
+      #  return(which(diff(x) > 0))
+      #}
+      #
+    #if( is.unsorted(depth[depth>z0])==TRUE){
+    #    warning("depth vector is unsorted")
+    #    return(data.frame(
+    #      min_depth = NA,
+    #      nseg = NA,
+    #      mld = NA,
+    #      cline = NA
+    #    ))
+    #  } else{
+   
     #
     ### Always only use the longest ordered portion
     ### Needed so that we can use an numbers rather than index for z0
-    #depth=depth[order_seq(depth)]
-    #measure=measure[order_seq(depth)]
+    #depth=depth[seq_rm(depth)]
+   # measure=measure[seq_rm(depth)]
     #
-    ### Set a minimum depth readings
-    if (length(depth) >= 10) {
-      #
-      #  ## For manual setting of depth vector
-      #  if (z0 == "auto") {
-      #    ## What is the minimum depth after finding longest ordered portion?
-      #    z0 = min(depth)
-      #    ##z0 must have minimum of 1 if using auto
-      #    if (z0 < 1) {
-      #      z0 = 1
-      #    }
-      #  } else {
-      #    z0 = z0
-      #  }
+
+      
+       # ## For manual setting of depth vector
+       # if (z0 == "auto") {
+       #   ## What is the minimum depth after finding longest ordered portion?
+       #   z0 = min(depth)
+       #   ##z0 must have minimum of 1 if using auto
+       #   if (z0 < 1) {
+       #     z0 = 1
+       #   }
+       # } else {
+       #   z0 = z0
+       # }
       
       
       
@@ -111,6 +146,7 @@ wtr_layer <-
         mld = NA,
         cline = NA
       ))
+    #}
     }
-      }
+    #}
   }

--- a/R/wtr_layer.R
+++ b/R/wtr_layer.R
@@ -3,7 +3,7 @@
 #' @param thres error norm; defaults to 0.1
 #' @param z0 initial depth in metres; defaults to auto whereby z0 is calculate as the first value of the longest ordered portion of the depth vector to minimum of 1. 
 #' @param zmax maximum depth in metres: defaults to 150m
-#' @param depth depth in metres; should be an increasing vector
+#' @param depth depth in metres; should be an increasing vector that has more than 10 elements
 #' @param measure parameter measured in the water column profile
 #' @param nseg optional parameter to define the number of segments a priori; defaults to an unconstrained approach whereby the algorithm determines segmentations by minimzing the error norm over each segment
 #' @return a dataframe of nseg (number of segments), mld (mix layer depth), cline (the midpoint of the segment connecting inflection points that has the maximum slope; thermocline for temperature measures)
@@ -33,12 +33,18 @@ wtr_layer <-
       return(s[w]:(s[w + 1] - 1L))
     }
     
+    ## Always only use the longest ordered portion
+    ## Needed so that we can use an numbers rather than index for z0
+    depth=depth[order_seq(depth)]
+    measure=measure[order_seq(depth)]
+    
     ## Set a minimum depth readings
     if (length(depth) >= 10) {
       
       ## For manual setting of depth vector
       if (z0 == "auto") {
-        z0 = depth[min(order_seq(depth))]
+        ## What is the minimum depth after finding longest ordered portion?
+        z0 = min(depth)
         ##z0 must have minimum of 1 if using auto
         if (z0 < 1) {
           z0 = 1

--- a/R/wtr_layer.R
+++ b/R/wtr_layer.R
@@ -25,7 +25,7 @@ wtr_layer <-
            depth = depth,
            measure = measure,
            nseg = "unconstrained") {
-    if( is.unsorted(depth)==TRUE){
+    if( is.unsorted(depth[depth>z0])==TRUE){
         warning("depth vector is unsorted")
         return(data.frame(
           min_depth = NA,

--- a/R/wtr_layer.R
+++ b/R/wtr_layer.R
@@ -18,43 +18,77 @@
 #' 
 ## Note accounting for difference between interval (nimax=neg-1) and segments (nseg=nimax+1)  
 #' @seealso \code{cline_calc()}
-wtr_layer <- function(thres=0.1,z0="auto",zmax=150,depth=depth,measure=measure, nseg="unconstrained"){
-  
-  ## Index numbers of longest ordered portion of a vector
-  ## http://stackoverflow.com/a/42077739/5596534
-  order_seq <- function(x) {
-    s = 1L + c(0L, which( x[-1L] < x[-length(x)] ), length(x))
-    w = which.max(diff(s))
-    return(s[w]:(s[w+1]-1L))
-  }
-  
-  ## For manual setting of depth vector
-  if( z0 == "auto" ){
-    z0 = depth[min(order_seq(depth))]
-    ##z0 must have minimum of 1 if using auto
-    if( z0 < 1 ){
-      z0 = 1
-    } 
-  } else {z0=z0}
-  
-
-  
-  if (nseg=="unconstrained"){
-    sam_list = by_s_m(thres = thres, z0 = z0, zmax = zmax, z = depth,sigma = measure)
-    return(data.frame(min_depth = z0,
-                      nseg = sam_list[["nimax"]]+1, 
-                      mld = sam_list[["by_s_m"]], 
-                      cline = cline_calc(z_seg = sam_list[["smz"]], sigma_seg = sam_list[["sms"]])
-                      )
-           ) 
+wtr_layer <-
+  function(thres = 0.1,
+           z0 = "auto",
+           zmax = 150,
+           depth = depth,
+           measure = measure,
+           nseg = "unconstrained") {
+    ## Index numbers of longest ordered portion of a vector
+    ## http://stackoverflow.com/a/42077739/5596534
+    order_seq <- function(x) {
+      s = 1L + c(0L, which(x[-1L] < x[-length(x)]), length(x))
+      w = which.max(diff(s))
+      return(s[w]:(s[w + 1] - 1L))
     }
-  else {
-    sam_list = by_s_m3(nr = nseg-1, z0 = z0, zmax = zmax, z = depth, sigma = measure)
-    return(data.frame(min_depth = z0,
-                      nseg = nseg, 
-                      mld = sam_list[["by_s_m"]], 
-                      cline = cline_calc(z_seg = sam_list[["smz"]], sigma_seg = sam_list[["sms"]])
-                      )
-           )
+    
+    ## Set a minimum depth readings
+    if (length(depth) >= 10) {
+      
+      ## For manual setting of depth vector
+      if (z0 == "auto") {
+        z0 = depth[min(order_seq(depth))]
+        ##z0 must have minimum of 1 if using auto
+        if (z0 < 1) {
+          z0 = 1
+        }
+      } else {
+        z0 = z0
+      }
+      
+      
+      
+      if (nseg == "unconstrained") {
+        sam_list = by_s_m(
+          thres = thres,
+          z0 = z0,
+          zmax = zmax,
+          z = depth,
+          sigma = measure
+        )
+        return(
+          data.frame(
+            min_depth = z0,
+            nseg = sam_list[["nimax"]] + 1,
+            mld = sam_list[["by_s_m"]],
+            cline = cline_calc(z_seg = sam_list[["smz"]], sigma_seg = sam_list[["sms"]])
+          )
+        )
+      }
+      else {
+        sam_list = by_s_m3(
+          nr = nseg - 1,
+          z0 = z0,
+          zmax = zmax,
+          z = depth,
+          sigma = measure
+        )
+        return(data.frame(
+          min_depth = z0,
+          nseg = nseg,
+          mld = sam_list[["by_s_m"]],
+          cline = cline_calc(z_seg = sam_list[["smz"]], sigma_seg = sam_list[["sms"]])
+        ))
+      }
+    } else {
+      warning("Profile does not have enough readings for sm algorithm (<10)")
+      return(data.frame(
+        min_depth = NA,
+        nseg = NA,
+        mld = NA,
+        cline = NA
+      ))
+    }
+    
   }
-}

--- a/R/wtr_layer.R
+++ b/R/wtr_layer.R
@@ -3,7 +3,7 @@
 #' @param thres error norm; defaults to 0.1
 #' @param z0 initial depth in metres; defaults to auto whereby z0 is calculate as the first value of the longest ordered portion of the depth vector to minimum of 1. 
 #' @param zmax maximum depth in metres: defaults to 150m
-#' @param depth depth in metres; should be an increasing vector that has more than 10 elements
+#' @param depth depth in metres; should be an increasing vector
 #' @param measure parameter measured in the water column profile
 #' @param nseg optional parameter to define the number of segments a priori; defaults to an unconstrained approach whereby the algorithm determines segmentations by minimzing the error norm over each segment
 #' @return a dataframe of nseg (number of segments), mld (mix layer depth), cline (the midpoint of the segment connecting inflection points that has the maximum slope; thermocline for temperature measures)
@@ -25,33 +25,47 @@ wtr_layer <-
            depth = depth,
            measure = measure,
            nseg = "unconstrained") {
-    ## Index numbers of longest ordered portion of a vector
-    ## http://stackoverflow.com/a/42077739/5596534
-    order_seq <- function(x) {
-      s = 1L + c(0L, which(x[-1L] < x[-length(x)]), length(x))
-      w = which.max(diff(s))
-      return(s[w]:(s[w + 1] - 1L))
-    }
-    
-    ## Always only use the longest ordered portion
-    ## Needed so that we can use an numbers rather than index for z0
-    depth=depth[order_seq(depth)]
-    measure=measure[order_seq(depth)]
-    
-    ## Set a minimum depth readings
+    if( is.unsorted(depth)==TRUE){
+        warning("depth vector is unsorted")
+        return(data.frame(
+          min_depth = NA,
+          nseg = NA,
+          mld = NA,
+          cline = NA
+        ))
+      } else{
+    ### Index numbers of longest ordered portion of a vector
+    ### http://stackoverflow.com/a/42077739/5596534
+    #order_seq <- function(x, run_length=10) {
+    #  ## Resistant to slight decreases in depth
+    #  ## returns Index range between first run of increasing numbers greater 10 and the max depth
+    #  ## Index where the runs start
+    #  s = 1L + c(0L, which(x[-1L] < x[-length(x)]), length(x))
+    #  ## Index of first run of numbers greater than run_lenght (defaults to 10)
+    #  w = min(which(diff(s) > run_length))
+    #  ## Index of fIrst instance of max depth
+    #  s[w]:min(which(x %in% max(x)))
+    #}
+    #
+    ### Always only use the longest ordered portion
+    ### Needed so that we can use an numbers rather than index for z0
+    #depth=depth[order_seq(depth)]
+    #measure=measure[order_seq(depth)]
+    #
+    ### Set a minimum depth readings
     if (length(depth) >= 10) {
-      
-      ## For manual setting of depth vector
-      if (z0 == "auto") {
-        ## What is the minimum depth after finding longest ordered portion?
-        z0 = min(depth)
-        ##z0 must have minimum of 1 if using auto
-        if (z0 < 1) {
-          z0 = 1
-        }
-      } else {
-        z0 = z0
-      }
+      #
+      #  ## For manual setting of depth vector
+      #  if (z0 == "auto") {
+      #    ## What is the minimum depth after finding longest ordered portion?
+      #    z0 = min(depth)
+      #    ##z0 must have minimum of 1 if using auto
+      #    if (z0 < 1) {
+      #      z0 = 1
+      #    }
+      #  } else {
+      #    z0 = z0
+      #  }
       
       
       
@@ -86,8 +100,10 @@ wtr_layer <-
           mld = sam_list[["by_s_m"]],
           cline = cline_calc(z_seg = sam_list[["smz"]], sigma_seg = sam_list[["sms"]])
         ))
+        
       }
-    } else {
+    }
+    else {
       warning("Profile does not have enough readings for sm algorithm (<10)")
       return(data.frame(
         min_depth = NA,
@@ -96,5 +112,5 @@ wtr_layer <-
         cline = NA
       ))
     }
-    
+      }
   }

--- a/R/wtr_segments.R
+++ b/R/wtr_segments.R
@@ -15,32 +15,73 @@
 #' 
 
 ## Note accounting for difference between interval (nimax=neg-1) and segments (nseg=nimax+1)  
-wtr_segments <- function(thres=0.1,z0="auto",zmax=150,depth=depth,measure=measure, nseg="unconstrained"){
-  
-  
-  ## Index numbers of longest ordered portion of a vector
-   ## http://stackoverflow.com/a/42077739/5596534
-   order_seq <- function(x) {
-     s = 1L + c(0L, which( x[-1L] < x[-length(x)] ), length(x))
-     w = which.max(diff(s))
-     return(s[w]:(s[w+1]-1L))
-   }
-   
-   ## For manual setting of depth vector
-   if( z0 == "auto" ){
-     z0 = depth[min(order_seq(depth))]
-     ##z0 must have minimum of 1 if using auto
-     if( z0 < 1 ){
-       z0 = 1
-     } 
-   } else {z0=z0}
-  
-  if( nseg=="unconstrained" ){
-    sam_list = by_s_m(thres=thres,z0=z0,zmax=zmax,z=depth,sigma=measure)
-    return(data.frame(min_depth=z0,nseg=sam_list[["nimax"]]+1, depth=sam_list[["smz"]], measure=sam_list[["sms"]]))
+wtr_segments <-
+  function(thres = 0.1,
+           z0 = "auto",
+           zmax = 150,
+           depth = depth,
+           measure = measure,
+           nseg = "unconstrained") {
+    ## Index numbers of longest ordered portion of a vector
+    ## http://stackoverflow.com/a/42077739/5596534
+    order_seq <- function(x) {
+      s = 1L + c(0L, which(x[-1L] < x[-length(x)]), length(x))
+      w = which.max(diff(s))
+      return(s[w]:(s[w + 1] - 1L))
+    }
+    
+    ## Set a minimum depth readings
+    if (length(depth) >= 10) {
+      ## For manual setting of depth vector
+      if (z0 == "auto") {
+        z0 = depth[min(order_seq(depth))]
+        ##z0 must have minimum of 1 if using auto
+        if (z0 < 1) {
+          z0 = 1
+        }
+      } else {
+        z0 = z0
+      }
+      
+      if (nseg == "unconstrained") {
+        sam_list = by_s_m(
+          thres = thres,
+          z0 = z0,
+          zmax = zmax,
+          z = depth,
+          sigma = measure
+        )
+        return(
+          data.frame(
+            min_depth = z0,
+            nseg = sam_list[["nimax"]] + 1,
+            depth = sam_list[["smz"]],
+            measure = sam_list[["sms"]]
+          )
+        )
+      }
+      else {
+        sam_list = by_s_m3(
+          nr = nseg - 1,
+          z0 = z0,
+          zmax = zmax,
+          z = depth,
+          sigma = measure
+        )
+        return(data.frame(
+          min_depth = z0,
+          nseg = nseg,
+          depth = sam_list[["smz"]],
+          measure = sam_list[["sms"]]
+        ))
+      }
+    } else {
+      warning("Profile does not have enough readings for sm algorithm (<10)")
+      return(data.frame(
+        min_depth = NA,
+        nseg = NA,
+        depth = NA,
+        measure = NA
+      ))
+    }
   }
-  else {
-    sam_list = by_s_m3(nr=nseg-1,z0=z0,zmax=zmax,z=depth,sigma=measure)
-    return(data.frame(min_depth=z0,nseg=nseg, depth=sam_list[["smz"]], measure=sam_list[["sms"]]))
-  }
-}

--- a/R/wtr_segments.R
+++ b/R/wtr_segments.R
@@ -3,7 +3,7 @@
 #' @param thres error norm; defaults to 0.1
 #' @param z0 initial depth in metres; defaults to auto whereby z0 is calculate as the first value of the longest ordered portion of the depth vector to minimum of 1. 
 #' @param zmax maximum depth in metres: default to 150m
-#' @param depth depth in metres; should be an increasing vector that has more than 10 elements
+#' @param depth depth in metres; should be an increasing vector
 #' @param measure parameter measured in the water column profile
 #' @param nseg optional parameter to define the number of segments a priori; defaults to an unconstrained approach whereby the algorithm determines segmentations by minimzing the error norm over each segment
 #' @return a dataframe of nseg (number of segments) and the x and y coordinates of the segments produced by the split and merge approach.
@@ -22,31 +22,47 @@ wtr_segments <-
            depth = depth,
            measure = measure,
            nseg = "unconstrained") {
-    ## Index numbers of longest ordered portion of a vector
-    ## http://stackoverflow.com/a/42077739/5596534
-    order_seq <- function(x) {
-      s = 1L + c(0L, which(x[-1L] < x[-length(x)]), length(x))
-      w = which.max(diff(s))
-      return(s[w]:(s[w + 1] - 1L))
-    }
-    
-    ## Always only use the longest ordered portion
-    ## Needed so that we can use an numbers rather than index for z0
-    depth=depth[order_seq(depth)]
-    measure=measure[order_seq(depth)]
-    
-    ## Set a minimum depth readings
+    if( is.unsorted(depth)==TRUE){
+      warning("depth vector is unsorted")
+      return(data.frame(
+        min_depth = NA,
+        nseg = NA,
+        depth = NA,
+        measure = NA
+      ))
+    } else{
+    ### Index numbers of longest ordered portion of a vector
+    ### http://stackoverflow.com/a/42077739/5596534
+    #order_seq <- function(x, run_length=10) {
+    #  ## Resistant to slight decreases in depth
+    #  ## returns Index range between first run of increasing numbers greater 10 and the max depth
+    #  ## Index where the runs start
+    #  s = 1L + c(0L, which(x[-1L] < x[-length(x)]), length(x))
+    #  ## Index of first run of numbers greater than run_lenght (defaults to 10)
+    #  w = min(which(diff(s) > run_length))
+    #  ## Index of fIrst instance of max depth
+    #  s[w]:min(which(x %in% max(x)))
+    #}
+    #
+    ### Always only use the longest ordered portion
+    ### Needed so that we can use an numbers rather than index for z0
+    #depth=depth[order_seq(depth)]
+    #measure=measure[order_seq(depth)]
+    #
+    ### Set a minimum depth readings
     if (length(depth) >= 10) {
-      ## For manual setting of depth vector
-      if (z0 == "auto") {
-        z0 = min(depth)
-        ##z0 must have minimum of 1 if using auto
-        if (z0 < 1) {
-          z0 = 1
-        }
-      } else {
-        z0 = z0
-      }
+      #
+      #  ## For manual setting of depth vector
+      #  if (z0 == "auto") {
+      #    ## What is the minimum depth after finding longest ordered portion?
+      #    z0 = min(depth)
+      #    ##z0 must have minimum of 1 if using auto
+      #    if (z0 < 1) {
+      #      z0 = 1
+      #    }
+      #  } else {
+      #    z0 = z0
+      #  }
       
       if (nseg == "unconstrained") {
         sam_list = by_s_m(
@@ -88,5 +104,6 @@ wtr_segments <-
         depth = NA,
         measure = NA
       ))
+    }
     }
   }

--- a/R/wtr_segments.R
+++ b/R/wtr_segments.R
@@ -22,7 +22,7 @@ wtr_segments <-
            depth = depth,
            measure = measure,
            nseg = "unconstrained") {
-    if( is.unsorted(depth)==TRUE){
+    if( is.unsorted(depth[depth>z0])==TRUE){
       warning("depth vector is unsorted")
       return(data.frame(
         min_depth = NA,

--- a/R/wtr_segments.R
+++ b/R/wtr_segments.R
@@ -17,20 +17,20 @@
 ## Note accounting for difference between interval (nimax=neg-1) and segments (nseg=nimax+1)  
 wtr_segments <-
   function(thres = 0.1,
-           z0 = "auto",
+           z0 = 1.5,
            zmax = 150,
            depth = depth,
            measure = measure,
            nseg = "unconstrained") {
-    if( is.unsorted(depth[depth>z0])==TRUE){
-      warning("depth vector is unsorted")
-      return(data.frame(
-        min_depth = NA,
-        nseg = NA,
-        depth = NA,
-        measure = NA
-      ))
-    } else{
+    #if( is.unsorted(depth[depth>z0])==TRUE){
+    #  warning("depth vector is unsorted")
+    #  return(data.frame(
+    #    min_depth = NA,
+    #    nseg = NA,
+    #    depth = NA,
+    #    measure = NA
+    #  ))
+    #} else{
     ### Index numbers of longest ordered portion of a vector
     ### http://stackoverflow.com/a/42077739/5596534
     #order_seq <- function(x, run_length=10) {
@@ -105,5 +105,5 @@ wtr_segments <-
         measure = NA
       ))
     }
-    }
+    #}
   }

--- a/R/wtr_segments.R
+++ b/R/wtr_segments.R
@@ -3,7 +3,7 @@
 #' @param thres error norm; defaults to 0.1
 #' @param z0 initial depth in metres; defaults to auto whereby z0 is calculate as the first value of the longest ordered portion of the depth vector to minimum of 1. 
 #' @param zmax maximum depth in metres: default to 150m
-#' @param depth depth in metres; should be an increasing vector
+#' @param depth depth in metres; should be an increasing vector that has more than 10 elements
 #' @param measure parameter measured in the water column profile
 #' @param nseg optional parameter to define the number of segments a priori; defaults to an unconstrained approach whereby the algorithm determines segmentations by minimzing the error norm over each segment
 #' @return a dataframe of nseg (number of segments) and the x and y coordinates of the segments produced by the split and merge approach.
@@ -30,11 +30,16 @@ wtr_segments <-
       return(s[w]:(s[w + 1] - 1L))
     }
     
+    ## Always only use the longest ordered portion
+    ## Needed so that we can use an numbers rather than index for z0
+    depth=depth[order_seq(depth)]
+    measure=measure[order_seq(depth)]
+    
     ## Set a minimum depth readings
     if (length(depth) >= 10) {
       ## For manual setting of depth vector
       if (z0 == "auto") {
-        z0 = depth[min(order_seq(depth))]
+        z0 = min(depth)
         ##z0 must have minimum of 1 if using auto
         if (z0 < 1) {
           z0 = 1

--- a/man/getxxnorm.Rd
+++ b/man/getxxnorm.Rd
@@ -2,20 +2,14 @@
 % Please edit documentation in R/getxxnorm.R
 \name{getxxnorm}
 \alias{getxxnorm}
-\title{Interpolate and normalize a vector of samples.}
+\title{Normalize a vector of samples.}
 \usage{
-getxxnorm(x, y, nn, x0, dx)
+getxxnorm(x, y)
 }
 \arguments{
 \item{x}{[REAL(N)] input x-axis array (should be in "chronological" order)}
 
 \item{y}{[REAL(N)] input y-axis array}
-
-\item{nn}{[INTEGER] input, desired dimension of output xx,yy vectors}
-
-\item{x0}{[REAL] start point along the x-axis; i.e., xx[1] = x0}
-
-\item{dx}{[REAL] step value for xx; i.e., dx = xx[i+1]-xx[i] for all i<nn}
 }
 \value{
 Output is a list with:
@@ -24,6 +18,6 @@ anormy, the normalization value used to make the last y == 1.
 xx,yy  vectors of x,y values interpolated to be the same length as x0.
 }
 \description{
-Interpolate and normalize a vector of samples. X and Y will be linearly interpolated to match the length of X0 and will be normalized so that the first point is (0,0) and the last point is (1,1). Vector x are the input x values, must be in ascending order.
+Normalize a vector of samples. X and Y  will be normalized so that the first point is (0,0) and the last point is (1,1). Vector x are the input x values, must be in ascending order.
 }
 

--- a/man/wtr_layer.Rd
+++ b/man/wtr_layer.Rd
@@ -4,7 +4,7 @@
 \alias{wtr_layer}
 \title{Exploration of lake water column layers}
 \usage{
-wtr_layer(thres = 0.1, z0 = "auto", zmax = 150, depth = depth,
+wtr_layer(thres = 0.1, z0 = 1.5, zmax = 150, depth = depth,
   measure = measure, nseg = "unconstrained")
 }
 \arguments{

--- a/man/wtr_layer.Rd
+++ b/man/wtr_layer.Rd
@@ -14,7 +14,7 @@ wtr_layer(thres = 0.1, z0 = "auto", zmax = 150, depth = depth,
 
 \item{zmax}{maximum depth in metres: defaults to 150m}
 
-\item{depth}{depth in metres; should be an increasing vector}
+\item{depth}{depth in metres; should be an increasing vector that has more than 10 elements}
 
 \item{measure}{parameter measured in the water column profile}
 

--- a/man/wtr_layer.Rd
+++ b/man/wtr_layer.Rd
@@ -14,7 +14,7 @@ wtr_layer(thres = 0.1, z0 = "auto", zmax = 150, depth = depth,
 
 \item{zmax}{maximum depth in metres: defaults to 150m}
 
-\item{depth}{depth in metres; should be an increasing vector that has more than 10 elements}
+\item{depth}{depth in metres; should be an increasing vector}
 
 \item{measure}{parameter measured in the water column profile}
 

--- a/man/wtr_segments.Rd
+++ b/man/wtr_segments.Rd
@@ -14,7 +14,7 @@ wtr_segments(thres = 0.1, z0 = "auto", zmax = 150, depth = depth,
 
 \item{zmax}{maximum depth in metres: default to 150m}
 
-\item{depth}{depth in metres; should be an increasing vector}
+\item{depth}{depth in metres; should be an increasing vector that has more than 10 elements}
 
 \item{measure}{parameter measured in the water column profile}
 

--- a/man/wtr_segments.Rd
+++ b/man/wtr_segments.Rd
@@ -4,7 +4,7 @@
 \alias{wtr_segments}
 \title{Exploration of lake water column segments}
 \usage{
-wtr_segments(thres = 0.1, z0 = "auto", zmax = 150, depth = depth,
+wtr_segments(thres = 0.1, z0 = 0.5, zmax = 150, depth = depth,
   measure = measure, nseg = "unconstrained")
 }
 \arguments{

--- a/man/wtr_segments.Rd
+++ b/man/wtr_segments.Rd
@@ -14,7 +14,7 @@ wtr_segments(thres = 0.1, z0 = "auto", zmax = 150, depth = depth,
 
 \item{zmax}{maximum depth in metres: default to 150m}
 
-\item{depth}{depth in metres; should be an increasing vector that has more than 10 elements}
+\item{depth}{depth in metres; should be an increasing vector}
 
 \item{measure}{parameter measured in the water column profile}
 

--- a/tests/testthat/test_wtr_layer.R
+++ b/tests/testthat/test_wtr_layer.R
@@ -25,5 +25,10 @@ test_that("NA's are returned when profile has less than 10 readings", {
   z = 1:8; sigmavar = rnorm(z)
   expect_warning(wtr_layer(depth=z, measure = sigmavar))
 })
+
+test_that("Unsorted vector fails", {
+  z <- c(1,2,1,0.5,1,4,2,1:10,2,3); sigmavar = rnorm(z)
+  expect_warning(wtr_layer(depth = z, measure =sigmavar))
+})
   
 

--- a/tests/testthat/test_wtr_layer.R
+++ b/tests/testthat/test_wtr_layer.R
@@ -5,3 +5,18 @@ test_that("Ensure that unconstrained and specified segment approach result in th
                 wtr_layer(depth=latesummer$depth, measure = latesummer$temper, 
                           nseg=wtr_layer(depth=latesummer$depth, measure = latesummer$temper)$nseg))
 })
+
+
+test_that("Ensures that increasing depth vectors are extracted from non-increasing vectors; order_seq is an internal function in wtr_layers",{
+  z <- c(1,2,1,0.5,1,4,2,1:10,2,3)
+  
+  ## Internal function in wtr_layer
+  order_seq <- function(x) {
+    s = 1L + c(0L, which( x[-1L] < x[-length(x)] ), length(x))
+    w = which.max(diff(s))
+    return(s[w]:(s[w+1]-1L))
+    }
+  
+  expect_equal(z[order_seq(z)], 1:10)
+})
+

--- a/tests/testthat/test_wtr_layer.R
+++ b/tests/testthat/test_wtr_layer.R
@@ -20,3 +20,10 @@ test_that("Ensures that increasing depth vectors are extracted from non-increasi
   expect_equal(z[order_seq(z)], 1:10)
 })
 
+test_that("NA's are returned when profile has less than 10 readings", {
+  # Data with less than 10 readings
+  z = 1:8; sigmavar = rnorm(z)
+  expect_warning(wtr_layer(depth=z, measure = sigmavar))
+})
+  
+

--- a/tests/testthat/test_wtr_segments.R
+++ b/tests/testthat/test_wtr_segments.R
@@ -5,3 +5,10 @@ test_that("Ensure that unconstrained and specified segment approach result in th
                 wtr_segments(depth=latesummer$depth, measure = latesummer$temper, 
                           nseg=unique(wtr_segments(depth=latesummer$depth, measure = latesummer$temper)$nseg)))
 })
+
+
+test_that("NA's are returned when profile has less than 10 readings", {
+  # Data with less than 10 readings
+  z = 1:8; sigmavar = rnorm(z)
+  expect_warning(wtr_segments(depth=z, measure = sigmavar))
+})


### PR DESCRIPTION
Stripped interpolation from getxxnorm and subsequent downstream requirements. This also removed the need for nn. The problem here is that this no longer passes the fortran comparison tests. This is reasonable as we won't be getting exactly the same numbers. Rather, the postulation here is that removal of interpolation is actually a better answer and therefore superior to the original fortran code results. My thought is that we simply need new tests but I wanted to get your input ahead or merging this into the master branch. 